### PR TITLE
increase compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ lowrisc_headers = \
 
 verilog_srcs = \
 	$(osd_dir)/interfaces/common/dii_channel.sv \
+	$(proj_dir)/src/Wrapper.v \
 	$(base_dir)/src/main/verilog/chip_top.sv \
 	$(base_dir)/src/main/verilog/spi_wrapper.sv \
 	$(base_dir)/socip/nasti/channel.sv \
@@ -90,6 +91,13 @@ verilog_srcs = \
 	$(glip_dir)/backend_uart/logic/verilog/glip_uart_receive.v \
 	$(glip_dir)/backend_uart/logic/verilog/glip_uart_toplevel.v \
 	$(glip_dir)/backend_uart/logic/verilog/glip_uart_transmit.v \
+	$(glip_dir)/common/logic/credit/verilog/debtor.v \
+	$(glip_dir)/common/logic/credit/verilog/creditor.v \
+	$(glip_dir)/common/logic/scaler/verilog/glip_downscale.v \
+	$(glip_dir)/common/logic/scaler/verilog/glip_upscale.v \
+	$(glip_dir)/common/logic/fifo/verilog/oh_fifo_sync.v \
+	$(glip_dir)/common/logic/fifo/verilog/oh_memory_ram.v \
+	$(glip_dir)/common/logic/fifo/verilog/oh_memory_dp.v \
 
 verilog_headers = \
 	$(base_dir)/src/main/verilog/config.vh \

--- a/constraint/pin_plan.xdc
+++ b/constraint/pin_plan.xdc
@@ -17,17 +17,20 @@ set_property PACKAGE_PIN W8 [get_ports SPI_SCLK]
 # ----------------------------------------------------------------------------
 # JC Pmod - Bank 13
 # ----------------------------------------------------------------------------
+
+# PMOD RS232
+
 set_property PACKAGE_PIN AB6 [get_ports UART_CTS]
 set_property PACKAGE_PIN AB7 [get_ports UART_RTS]
 set_property PACKAGE_PIN AA4 [get_ports UART_TX]
 set_property PACKAGE_PIN Y4 [get_ports UART_RX]
-#set_property PACKAGE_PIN T6  [get_ports {JC3_N}];  # "JC3_N"
-#set_property PACKAGE_PIN R6  [get_ports {JC3_P}];  # "JC3_P"
-#set_property PACKAGE_PIN U4  [get_ports {JC4_N}];  # "JC4_N"
-#set_property PACKAGE_PIN T4  [get_ports {JC4_P}];  # "JC4_P"
 
-#set_property IOSTANDARD LVCMOS33 [get_ports {UART_RX}]
-#set_property IOSTANDARD LVCMOS33 [get_ports {UART_TX}]
+# PMOD USBUART
+
+#set_property PACKAGE_PIN AB6 [get_ports UART_TX]
+#set_property PACKAGE_PIN AB7 [get_ports UART_CTS]
+#set_property PACKAGE_PIN AA4 [get_ports UART_RTS]
+#set_property PACKAGE_PIN Y4 [get_ports UART_RX]
 
 set_property IOSTANDARD LVCMOS33 [get_ports -of_objects [get_iobanks 13]]
 

--- a/helperscript/xsdk_script.tcl
+++ b/helperscript/xsdk_script.tcl
@@ -1,7 +1,7 @@
 #!/usr/bin/tclsh
 connect -url tcp:127.0.0.1:3121
 source ./helperscript/ps7_init.tcl
-targets -set -filter {name =~"APU" && jtag_cable_name =~ "Digilent Zed 210248687092"} -index 0
+targets -set -filter {name =~"APU" && jtag_cable_name =~ "Digilent Zed *"} -index 0
 rst -system
 ps7_init
 ps7_post_config

--- a/script/make_project.tcl
+++ b/script/make_project.tcl
@@ -100,7 +100,9 @@ set files [list \
                [file normalize $glip_dir/common/logic/credit/verilog/creditor.v] \
                [file normalize $glip_dir/common/logic/scaler/verilog/glip_downscale.v] \
                [file normalize $glip_dir/common/logic/scaler/verilog/glip_upscale.v] \
-               [file normalize $glip_dir/common/logic/interface/glip_channel.sv] \
+               [file normalize $glip_dir/common/logic/fifo/verilog/oh_fifo_sync.v] \
+               [file normalize $glip_dir/common/logic/fifo/verilog/oh_memory_ram.v] \
+               [file normalize $glip_dir/common/logic/fifo/verilog/oh_memory_dp.v] \
              ]
 add_files -norecurse -fileset [get_filesets sources_1] $files
 

--- a/script/zed_bd.tcl
+++ b/script/zed_bd.tcl
@@ -18,19 +18,6 @@ variable script_folder
 set script_folder [_tcl::get_script_folder]
 
 ################################################################
-# Check if script is running in correct Vivado version.
-################################################################
-set scripts_vivado_version 2016.2
-set current_vivado_version [version -short]
-
-if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
-   puts ""
-   catch {common::send_msg_id "BD_TCL-109" "ERROR" "This script was generated using Vivado <$scripts_vivado_version> and is being run in <$current_vivado_version> of Vivado. Please run the script in Vivado <$scripts_vivado_version> then open the design in Vivado <$current_vivado_version>. Upgrade the design by running \"Tools => Report => Report IP Status...\", then run write_bd_tcl to create an updated script."}
-
-   return 1
-}
-
-################################################################
 # START
 ################################################################
 


### PR DESCRIPTION
This PR tries to resolve a couple of issues:

+ Add the missing source files to Makefile therefore make can automatically recompile when files changed.
+ Unfortunately PMOD RS232 and PMOD USBUART do not share the same pin order. The pin assignment for PMOD USBART is added in `pin_plan.xdc`.
+ Remove the exact serial ID in `xsdk_script.tcl` as different board can have different serial ID.
+ Remove the unnecessary version check in `zed_bd.tcl`.

Some suggestions to the README.md and the PR towards lowrisc-site tutorial.

+ Do NOT explicitly and manually checkout the master branch of lowrisc-zed. The reason to have a root repo (lowrisc-chip) and using submodules is to pin specific commit of submodules. If asking users to manually checkout master branch, commits will be easily losing tracks. Anytime you need to bump versions for lowrisc-zed, give me an email or send a PR, which can be done quickly. If this is still too troublesome if frequently version bumps are needed, we can give you direct access to the lowrisc repos.
+ The order of source environment setup scripts. set_env.sh should be the last script to be sourced because it can analyse the existing variables and setting the missing ones.
+ The change to set_env.sh should be changed I think. What you really want is $RISCV/lib rather than $TOP/riscv/lib. The latter one assume users install riscv to $TOP/riscv, but they can choose to do differently. set_env.sh should respect users' own specialization.
+ Before source set_env.sh, `FPGA_BOARD` variable should be set and exposed to `zed`.
+ The URL to PMOD RS232 is wrong?
+ Describe the different pin assignment for PMOD RS232 and PMOD USBUART.

Remaining issues I cannot handle right now:
+ The IP versions in `zed_bd.tcl` are fixed.  This would cause problem if some one use a different version of Vivado which provides different versions of these IPs. A better way would be checking the versions of locally installed IPs and dynamically assemble the IP identification string. (too troublesome, leave it for now)
+ I do not have a PMOD SD so I cannot test the standalone Linux boot procedure.
+ I tried to implement a version with the trace debugger therefore I can dump Linux kernel to DDR. However, the current trace debugger code fails to pass DRC due to some uses of Xilinx dual-port FIFO macro. I even tried to bump the version of glip to pass DRC. Then there is no response from the trace debugger overridden UART port. Reducing baud rate does not help. There must be some version mismatch which I do not have time to resolve for now.
+ I probably need to modify the chip_top.sv after all the above issues have been resolved to recover indentation and put the Zed part as later choice in Macro controlled port selection. 