### PR TITLE
emit SystemVerilog for better assertions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ include $(base_dir)/Makefrag
 #--------------------------------------------------------------------
 
 lowrisc_srcs = \
-	$(generated_dir)/$(MODEL).$(CONFIG).v \
+	$(generated_dir)/$(MODEL).$(CONFIG).sv \
 
 lowrisc_headers = \
 	$(generated_dir)/consts.vh \

--- a/script/make_project.tcl
+++ b/script/make_project.tcl
@@ -46,7 +46,7 @@ source $origin_dir/script/zed_bd.tcl
 # Set 'sources_1' fileset object
 set files [list \
                [file normalize $origin_dir/src/Wrapper.v] \
-               [file normalize $origin_dir/generated-src/Top.$CONFIG.v] \
+               [file normalize $origin_dir/generated-src/Top.$CONFIG.sv] \
                [file normalize $osd_dir/interfaces/common/dii_channel.sv ] \
                [file normalize $base_dir/src/main/verilog/chip_top.sv] \
                [file normalize $base_dir/src/main/verilog/spi_wrapper.sv] \


### PR DESCRIPTION
An update of Makefile and make_project due to changes in lowrisc-chip.
The simulation related verilog for Chisel assertion is changed to use SystemVerilog features.
To comply with standard, the suffix of the generated Verilog file is changed from .v to .sv